### PR TITLE
FIX: Github Actions CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Lint, Static Analysis, Tests
 
-on: [push, pull_request]
+on: push
 
 permissions:
   contents: read


### PR DESCRIPTION
### Modification
- Fixed ci workflow permission 
- Fixed coverage report path so that can be used to generate report table 

## Previous CI Errors
```
Error: fatal: repository '......' Repository not found
Error: The process '/usr/bin/git' failed with exit code 128
```

```
Error: No files found matching glob pattern.
``` 


### References:
- https://github.com/actions/checkout/issues/254#issuecomment-1994464504