### PR TITLE
Fix: Run ci workflow on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Lint, Static Analysis, Tests
 
-on: push
+on: ["push", "pull_request"]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Modification
- modified ci workflow to run on pull request so that coverage report PR comment will be made