### PR TITLE
Fix: Add write permission to CI for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Lint, Static Analysis, Tests
 on: ["push", "pull_request"]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION

### Error
```
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/SarahTeoh/key-value-store/': The requested URL returned error: 403
```

### Modification
- grant ci permission to write content for linting